### PR TITLE
Pinning Joomla to version 3.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN \
     apt-get update &&\
     apt-get install -y zip unzip libmcrypt-dev libpng12-dev libjpeg-dev php7.1-gd php7.1-mysql curl &&\
     rm -rf /var/lib/apt/lists/* &&\
-    JOOMLA_DOWNLOAD=https://downloads.joomla.org$(curl -fsL https://downloads.joomla.org/latest | grep -iEo '/cms/joomla3/.*-stable-full_package[-\.]tar[-\.]gz\?format=gz' | sort -nr | uniq | head -1) && \
+    # JOOMLA_DOWNLOAD=https://downloads.joomla.org$(curl -fsL https://downloads.joomla.org/latest | grep -iEo '/cms/joomla3/.*-stable-full_package[-\.]tar[-\.]gz\?format=gz' | sort -nr | uniq | head -1) && \
+    JOOMLA_DOWNLOAD=https://downloads.joomla.org$(curl -fsL https://downloads.joomla.org/cms/joomla3/3-7-3 | grep -iEo '/cms/joomla3/.*-stable-full_package[-\.]tar[-\.]gz\?format=gz' | sort -nr | uniq | head -1) && \
     echo "Downloading from $JOOMLA_DOWNLOAD" && \
     curl -fsL $JOOMLA_DOWNLOAD -o /usr/src/joomla.tar.gz && \
     sha1sum /usr/src/joomla.tar.gz && \


### PR DESCRIPTION
Joomla 3.7.4 introduces a new security check for the installation process which is triggered when the user attempts to configure a database which isn't on localhost. This is our only use case. 

The security check doesn't appear to allow you to progress even if you follow the instructions. 

There are several bug reports and pull requests against the Joomla project. It appears the problem will be fixed in the future version. Until then pinning this image to the previous version so that we are able to get installations to go through with minimal hassle.